### PR TITLE
add hostname

### DIFF
--- a/Attire-ExecutionLogger.psm1
+++ b/Attire-ExecutionLogger.psm1
@@ -16,6 +16,8 @@ function Start-ExecutionLog($startTime, $logPath, $targetHostname, $targetUser, 
             $ipAddress = $(ifconfig | grep 'inet ' | grep -Fv 127.0.0.1 | awk '{print $2;exit}')
         }
     }
+    
+    $targetHostname = hostname
 
     $target = [PSCustomObject]@{
         user = $targetUser


### PR DESCRIPTION
The code for acquiring the Windows target IP address is not accurate.  on my system, for example, it grabs an IPV6 address,  The `-first 1` in the command appears to be the issue.  I am adding a line to acquire the hostname as well.  We should try to write a more accurate line for obtaining the windows target IPV4 address.