### PR TITLE
pass full response object

### DIFF
--- a/Attire-ExecutionLogger.psm1
+++ b/Attire-ExecutionLogger.psm1
@@ -45,7 +45,7 @@ function Start-ExecutionLog($startTime, $logPath, $targetHostname, $targetUser, 
     $script:attireLog.'execution-data' = $executionData
 }
 
-function Write-ExecutionLog($startTime, $stopTime, $technique, $testNum, $testName, $testGuid, $testExecutor, $testDescription, $command, $logPath, $targetHostname, $targetUser, $stdOut, $stdErr, $isWindows) {
+function Write-ExecutionLog($startTime, $stopTime, $technique, $testNum, $testName, $testGuid, $testExecutor, $testDescription, $command, $logPath, $targetHostname, $targetUser, $res, $isWindows) {
 
     $startTime = (Get-Date($startTime).ToUniversalTime() -UFormat '+%Y-%m-%dT%H:%M:%S.000Z').ToString()
     $stopTime = (Get-Date($stopTime).ToUniversalTime() -UFormat '+%Y-%m-%dT%H:%M:%S.000Z').ToString()
@@ -65,22 +65,22 @@ function Write-ExecutionLog($startTime, $stopTime, $technique, $testNum, $testNa
     }
 
     $outputStdConole = [PSCustomObject]@{
-        content = $stdOut
+        content = $res.stdOut
         level = "STDOUT"
         type = "console"
     }
 
     $outputErrConole = [PSCustomObject]@{
-        content = $stdErr
+        content = $res.stdErr
         level = "STDERR"
         type = "console"
     }
 
-    if($stdOut.length -gt 0) {
+    if($res.stdOut.length -gt 0) {
         $step.output += $outputStdConole
     }
 
-    if($stdErr.length -gt 0) {
+    if($res.stdErr.length -gt 0) {
         $step.output += $outputErrConole
     }
 


### PR DESCRIPTION
Invoke-AtomicRedTeam is changing in [this PR](https://github.com/redcanaryco/invoke-atomicredteam/pull/116) to pass the full $response object to the Write-ExecutionLog method and the $response object will now include the process ID and exit code.

Do you mind if we put a copy of Attire-ExecutionLogger.psm1 directly into the Invoke-AtomicRedTeam project so it is easier for people to use (no need to download and import separately) and also easier to keep its version in sync with the Invoke-AtomicRedTeam version?